### PR TITLE
Undo exit message deletion

### DIFF
--- a/fftools/cmdutils.c
+++ b/fftools/cmdutils.c
@@ -134,6 +134,14 @@ void exit_program(int ret)
 {
     if (program_exit)
         program_exit(ret);
+
+    /*
+     * Print an unique message here to detect
+     * end of operation in JavaScript.
+     */
+    printf("FFMPEG_END\n");
+
+    exit(ret);
 }
 
 double parse_number_or_die(const char *context, const char *numstr, int type,


### PR DESCRIPTION
This push closes issue FFmpeg-wasm/FFmpeg.wasm#4 the bug where the FFmpeg run command hang indefinitely when running in the browser. As described in the issue, it was waiting for the "FFMPEG_END" message but never received it as it was removed from core.

I have re-build with this change and confirmed it has fixed things! FFmpeg run no longer hangs and finishes the command correctly to continue on with execution